### PR TITLE
feat: simplify MCP server deployment for OpenShift

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,64 @@
+# Use Red Hat UBI9 Python 3.11 base image
+FROM registry.access.redhat.com/ubi9/python-311:1-1753713955
+
+# Set labels for better image management
+LABEL name="mcp-server" \
+      version="1.0" \
+      description="MCP Server with FastMCP framework for OpenShift" \
+      maintainer="cfchase"
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+# Set working directory (UBI image uses /opt/app-root/src by default)
+WORKDIR /opt/app-root/src
+
+# Install uv for fast dependency management
+RUN pip install --upgrade pip && \
+    pip install uv
+
+# Copy dependency files as root
+USER 0
+COPY --chown=1001:0 pyproject.toml uv.lock ./
+
+# Switch back to default user
+USER 1001
+
+# Create UV cache directory with proper permissions for OpenShift
+RUN mkdir -p /opt/app-root/src/.cache/uv && \
+    chmod -R g+rwX /opt/app-root/src/.cache
+
+# Install Python dependencies using uv
+RUN uv sync --frozen --no-dev
+
+# Copy application code
+COPY --chown=1001:0 main.py ./
+
+# Create directories for image storage with proper permissions
+RUN mkdir -p /opt/app-root/src/images && \
+    chmod -R g+rwX /opt/app-root/src/images
+
+# Fix permissions for OpenShift - ensure all files are group writable
+RUN chgrp -R 0 /opt/app-root/src && \
+    chmod -R g=u /opt/app-root/src
+
+# Set default environment variables (can be overridden in deployment)
+ENV IMAGE_OUTPUT_PATH=/opt/app-root/src/images \
+    DIFFUSERS_RUNTIME_URL=http://tiny-sd:8080 \
+    DIFFUSERS_MODEL_ID=model \
+    PORT=8080
+
+# Expose the application port (UBI convention is 8080)
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import httpx; httpx.get('http://localhost:8080/health')" || exit 1
+
+# Start the MCP server
+CMD ["uv", "run", "python", "main.py", "--port", "8080"]

--- a/mcp-server/Makefile
+++ b/mcp-server/Makefile
@@ -1,7 +1,19 @@
-.PHONY: help install test test-diffusers run clean
+# MCP Server Deployment Makefile
+CONTAINER_RUNTIME ?= docker
+REGISTRY ?= quay.io/cfchase
+IMAGE_NAME ?= image-generation-mcp
+IMAGE_TAG ?= latest
+IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+# Deployment variables
+MCP_SERVER_NAME ?= image-generation-mcp
+DIFFUSERS_RUNTIME_URL ?= http://redhat-dog-predictor:8080
+DIFFUSERS_MODEL_ID ?= model
+
+.PHONY: help build push deploy undeploy test test-local clean
 
 help: ## Show this help message
-	@echo "MCP Server - Image Generation Server using diffusers-runtime"
+	@echo "MCP Server - Simple deployment for OpenShift"
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""
@@ -9,31 +21,48 @@ help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ""
 	@echo "Environment Variables:"
-	@echo "  DIFFUSERS_RUNTIME_URL   URL of diffusers-runtime (default: http://0.0.0.0:8080)"
-	@echo "  DIFFUSERS_MODEL_ID      Model ID to use (default: model)"
-	@echo "  IMAGE_OUTPUT_PATH       Directory to save images (default: /tmp/image-generator)"
+	@echo "  CONTAINER_RUNTIME       Container runtime (default: docker)"
+	@echo "  REGISTRY               Container registry (default: quay.io/cfchase)"
+	@echo "  IMAGE_TAG              Image tag (default: latest)"
+	@echo "  DIFFUSERS_RUNTIME_URL  Diffusers runtime URL (default: http://redhat-dog-predictor)"
 	@echo ""
-	@echo "Quick Start:"
-	@echo "  make run    # Starts unified server with MCP on /mcp and images on /images"
+	@echo "Example:"
+	@echo "  make build push deploy  # Build, push, and deploy to OpenShift"
 
-install: ## Install dependencies using uv
-	uv pip install -e .
+build: ## Build container image
+	$(CONTAINER_RUNTIME) build -t $(IMAGE) .
 
-test: ## Test the generate_image function directly
-	.venv/bin/python test_generate.py
+push: ## Push container image to registry
+	$(CONTAINER_RUNTIME) push $(IMAGE)
 
-test-diffusers: ## Test connection to diffusers-runtime service
-	@echo "Testing diffusers-runtime at http://0.0.0.0:8080..."
-	@curl -s -X POST http://0.0.0.0:8080/v1/models/model:predict \
-		-H "Content-Type: application/json" \
-		-d '{"instances": [{"prompt": "test image", "num_inference_steps": 20}]}' \
-		| jq -r '.predictions[0].model_name' || echo "Error: Is diffusers-runtime running? (make dev in diffusers-runtime/)"
+deploy: ## Deploy to OpenShift
+	@echo "Deploying MCP Server to OpenShift..."
+	@export MCP_SERVER_NAME=$(MCP_SERVER_NAME) \
+		MCP_IMAGE=$(IMAGE) \
+		DIFFUSERS_RUNTIME_URL=$(DIFFUSERS_RUNTIME_URL) \
+		DIFFUSERS_MODEL_ID=$(DIFFUSERS_MODEL_ID) && \
+	envsubst < templates/mcp-server.yaml | oc apply -f -
+	@echo ""
+	@echo "Deployment complete. To access the MCP server:"
+	@echo "  oc get route $(MCP_SERVER_NAME)"
 
-run: ## Run unified server with MCP on /mcp and images on /images
-	.venv/bin/python main.py --port 8000
+undeploy: ## Remove deployment from OpenShift
+	@echo "Removing MCP Server from OpenShift..."
+	@export MCP_SERVER_NAME=$(MCP_SERVER_NAME) \
+		MCP_IMAGE=$(IMAGE) \
+		DIFFUSERS_RUNTIME_URL=$(DIFFUSERS_RUNTIME_URL) \
+		DIFFUSERS_MODEL_ID=$(DIFFUSERS_MODEL_ID) && \
+	envsubst < templates/mcp-server.yaml | oc delete -f -
 
-clean: ## Clean generated images
+test: ## Test deployed MCP server on OpenShift
+	@echo "Testing MCP Server on OpenShift..."
+	@./scripts/test_with_port_forward.sh
+
+test-local: ## Test local MCP server
+	@echo "Testing local MCP Server..."
+	MCP_URL="http://127.0.0.1:8000/mcp" .venv/bin/python scripts/test_generate.py
+
+clean: ## Clean generated images and temp files
 	rm -rf images/
-	rm -rf /tmp/image-generator/
 	rm -rf test_output/
 	rm -f example_output.png

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -201,8 +201,8 @@ def main(port: int):
     print(f"📊 Health check: http://localhost:{port}/health")
     print(f"📚 API docs: http://localhost:{port}/docs\n")
     
-    # Run the unified server
-    mcp.run(transport="http", port=port)
+    # Run the unified server (bind to 0.0.0.0 for container access)
+    mcp.run(transport="http", port=port, host="0.0.0.0")
 
 
 if __name__ == "__main__":

--- a/mcp-server/scripts/test_api.py
+++ b/mcp-server/scripts/test_api.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Simple API test for the deployed MCP server"""
+
+import httpx
+import json
+import os
+import sys
+from pathlib import Path
+import time
+
+# Get base URL from environment or use local default
+BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8000")
+print(f"Testing API at: {BASE_URL}")
+
+def test_health():
+    """Test the health endpoint"""
+    print("\n1. Testing health endpoint...")
+    try:
+        response = httpx.get(f"{BASE_URL}/health", timeout=10.0)
+        response.raise_for_status()
+        data = response.json()
+        print(f"   ✅ Health check passed: {data}")
+        return True
+    except Exception as e:
+        print(f"   ❌ Health check failed: {e}")
+        return False
+
+def test_image_list():
+    """Test listing images"""
+    print("\n2. Testing image list endpoint...")
+    try:
+        response = httpx.get(f"{BASE_URL}/images", timeout=10.0)
+        response.raise_for_status()
+        data = response.json()
+        print(f"   ✅ Image list retrieved: {len(data.get('images', []))} images")
+        return True
+    except Exception as e:
+        print(f"   ❌ Image list failed: {e}")
+        return False
+
+def test_mcp_direct():
+    """Test MCP endpoint directly with a tool call"""
+    print("\n3. Testing MCP tool call directly...")
+    
+    # Create a direct MCP request for generate_image
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "generate_image",
+            "arguments": {
+                "prompt": "a simple test image of a red circle on white background",
+                "num_inference_steps": 20
+            }
+        },
+        "id": "test-1"
+    }
+    
+    try:
+        # MCP uses Server-Sent Events, so we need to handle streaming
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream"
+        }
+        
+        print("   📤 Sending MCP request...")
+        response = httpx.post(
+            f"{BASE_URL}/mcp/",
+            headers=headers,
+            json=mcp_request,
+            timeout=60.0  # Image generation can take time
+        )
+        
+        # Parse SSE response
+        content = response.text
+        print(f"   📥 Response status: {response.status_code}")
+        
+        if response.status_code == 200:
+            # Extract data from SSE format
+            for line in content.split('\n'):
+                if line.startswith('data: '):
+                    data = json.loads(line[6:])
+                    if 'result' in data:
+                        print(f"   ✅ Image generated: {data['result'].get('content', ['No content'])[0].get('text', 'No text')[:100]}")
+                        return True
+                    elif 'error' in data:
+                        print(f"   ❌ MCP error: {data['error']}")
+                        return False
+        else:
+            print(f"   ❌ Request failed: {content[:200]}")
+            return False
+            
+    except Exception as e:
+        print(f"   ❌ MCP test failed: {e}")
+        return False
+
+def main():
+    """Run all tests"""
+    print(f"\n🧪 Running API tests for: {BASE_URL}\n")
+    
+    results = []
+    
+    # Run tests
+    results.append(("Health Check", test_health()))
+    results.append(("Image List", test_image_list()))
+    results.append(("MCP Tool Call", test_mcp_direct()))
+    
+    # Summary
+    print("\n📊 Test Summary:")
+    print("-" * 40)
+    passed = sum(1 for _, result in results if result)
+    total = len(results)
+    
+    for test_name, result in results:
+        status = "✅ PASS" if result else "❌ FAIL"
+        print(f"{test_name:.<30} {status}")
+    
+    print("-" * 40)
+    print(f"Total: {passed}/{total} tests passed")
+    
+    # Exit with error if any test failed
+    if passed < total:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/scripts/test_generate.py
+++ b/mcp-server/scripts/test_generate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Test script to verify the MCP server with diffusers-runtime integration"""
+
+import asyncio
+import httpx
+import re
+import os
+import sys
+from pathlib import Path
+from fastmcp import Client
+
+# Get MCP server URL from environment or use default
+MCP_URL = os.environ.get("MCP_URL", "http://127.0.0.1:8000/mcp")
+print(f"Using MCP server at: {MCP_URL}")
+
+# Connect to the HTTP server
+client = Client({"mcpServers": {
+    "image_generator": {
+        "transport": "http",
+        "url": MCP_URL
+    }
+}})
+
+async def download_image_from_url(url: str, filename: str):
+    """Download image from URL and save it locally"""
+    try:
+        async with httpx.AsyncClient() as http_client:
+            response = await http_client.get(url, timeout=30.0)
+            response.raise_for_status()
+            
+            # Save image to test_output directory
+            output_dir = Path("test_output")
+            output_dir.mkdir(exist_ok=True)
+            
+            output_path = output_dir / filename
+            output_path.write_bytes(response.content)
+            
+            print(f"  ✅ Downloaded image to: {output_path}")
+            return output_path
+    except Exception as e:
+        print(f"  ❌ Failed to download image: {e}")
+        return None
+
+
+async def extract_and_download_image(result_data: str, test_name: str):
+    """Extract URL from result and download image if it's a URL"""
+    # Check if result contains a URL
+    url_match = re.search(r'(https?://[^\s]+\.png)', result_data)
+    if url_match:
+        url = url_match.group(1)
+        # Replace localhost:8080 with 127.0.0.1:8000 for port-forwarded access
+        if "localhost:8080" in url:
+            url = url.replace("localhost:8080", "127.0.0.1:8000")
+        print(f"  🔗 Image URL: {url}")
+        filename = f"{test_name}_{url.split('/')[-1]}"
+        await download_image_from_url(url, filename)
+    else:
+        # Check if it's a file path
+        path_match = re.search(r'Image saved to: (.+\.png)', result_data)
+        if path_match:
+            print(f"  📁 Image path: {path_match.group(1)}")
+        else:
+            print(f"  ⚠️  No image URL or path found in result")
+
+
+async def test_generate_image():
+    try:
+        async with client:
+            # Test 1: Simple prompt (fast)
+            print("\n🎨 Test 1: Generating image with simple prompt...")
+            result = await client.call_tool("generate_image", {
+                "prompt": "a beautiful sunset over the ocean",
+                "num_inference_steps": 20  # Faster for testing
+            })
+            print(f"Result: {result}")
+            if hasattr(result, 'data'):
+                await extract_and_download_image(result.data, "test1")
+            print()
+            
+            # Test 2: With negative prompt
+            print("🎨 Test 2: Generating image with negative prompt...")
+            result = await client.call_tool("generate_image", {
+                "prompt": "a futuristic city at night",
+                "negative_prompt": "blurry, low quality, distorted",
+                "num_inference_steps": 25  # Reasonable quality
+            })
+            print(f"Result: {result}")
+            if hasattr(result, 'data'):
+                await extract_and_download_image(result.data, "test2")
+            print()
+            
+            # Test 3: Check if server handles errors gracefully
+            print("🎨 Test 3: Testing error handling with invalid parameters...")
+            try:
+                result = await client.call_tool("generate_image", {
+                    "prompt": "test image",
+                    "num_inference_steps": -1  # Invalid value
+                })
+                print(f"Result: {result}")
+            except Exception as e:
+                print(f"  ✅ Error handled correctly: {e}")
+            print()
+            
+            print("\n✅ All tests completed!")
+            
+    except Exception as e:
+        print(f"\n❌ Test failed with error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(test_generate_image())

--- a/mcp-server/scripts/test_with_port_forward.sh
+++ b/mcp-server/scripts/test_with_port_forward.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test script that uses port forwarding to test the MCP server
+
+echo "🚀 Starting test with port forwarding..."
+
+# Get the pod name
+POD=$(oc get pods -l app=image-generation-mcp -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$POD" ]; then
+    echo "❌ No pod found for image-generation-mcp"
+    exit 1
+fi
+
+echo "📦 Using pod: $POD"
+
+# Start port forwarding in background
+echo "🔗 Starting port forwarding..."
+oc port-forward $POD 8000:8080 &
+PF_PID=$!
+
+# Give it time to start
+sleep 3
+
+# Run the test
+echo "🧪 Running MCP test..."
+MCP_URL="http://127.0.0.1:8000/mcp" .venv/bin/python scripts/test_generate.py
+
+# Capture test result
+TEST_RESULT=$?
+
+# Kill port forwarding
+echo "🛑 Stopping port forwarding..."
+kill $PF_PID 2>/dev/null
+
+# Exit with test result
+exit $TEST_RESULT

--- a/mcp-server/templates/mcp-server.yaml
+++ b/mcp-server/templates/mcp-server.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${MCP_SERVER_NAME}
+  labels:
+    app: ${MCP_SERVER_NAME}
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: ${MCP_SERVER_NAME}
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${MCP_SERVER_NAME}
+  labels:
+    app: ${MCP_SERVER_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${MCP_SERVER_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${MCP_SERVER_NAME}
+    spec:
+      containers:
+      - name: mcp-server
+        image: ${MCP_IMAGE}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "8080"
+        - name: DIFFUSERS_RUNTIME_URL
+          value: "${DIFFUSERS_RUNTIME_URL}"
+        - name: DIFFUSERS_MODEL_ID
+          value: "${DIFFUSERS_MODEL_ID}"
+        - name: IMAGE_OUTPUT_PATH
+          value: "/opt/app-root/src/images"
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ${MCP_SERVER_NAME}
+  labels:
+    app: ${MCP_SERVER_NAME}
+spec:
+  to:
+    kind: Service
+    name: ${MCP_SERVER_NAME}
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
## Summary
- Simplified MCP server deployment from complex Kustomize structure to minimalist single-template approach
- Replaced 3-environment setup (dev/staging/prod) with single deployment using environment variables
- Fixed container compatibility issues for OpenShift deployment

## Changes
### Deployment Simplification
- Created single `templates/mcp-server.yaml` with environment variable substitution
- Removed all Kustomize complexity (no more overlays/base structure)
- Simplified Makefile to essential targets only: `build`, `push`, `deploy`, `undeploy`, `test`

### Container Fixes
- Added proper permissions for OpenShift (UV cache, file permissions)
- Fixed network binding to use `0.0.0.0` instead of `127.0.0.1`
- Used Red Hat UBI9 Python 3.11 base image

### Testing Infrastructure
- Added `scripts/test_generate.py` - MCP protocol integration test
- Added `scripts/test_api.py` - Direct API endpoint testing
- Added `scripts/test_with_port_forward.sh` - Port forwarding wrapper for tests
- Created `make test` target for easy testing

## Deployment Instructions
```bash
# Build and push container
make build
make push

# Deploy to OpenShift
make deploy

# Test the deployment
make test

# Remove deployment
make undeploy
```

## Configuration
Environment variables (with defaults):
- `CONTAINER_RUNTIME`: docker or podman (default: docker)
- `REGISTRY`: Container registry (default: quay.io/cfchase)
- `IMAGE_TAG`: Image tag (default: latest)
- `DIFFUSERS_RUNTIME_URL`: Diffusers service URL (default: http://redhat-dog-predictor:8080)

## Testing
Successfully tested on OpenShift cluster:
- ✅ Health check endpoint working
- ✅ MCP server accepting connections
- ✅ Image generation via diffusers-runtime integration
- ✅ Generated test images successfully

Fixes #11